### PR TITLE
feat: supports qemu without vvfat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/esp
+/esp*
 /.idea
 /.vscode
 **/target

--- a/ysos.py
+++ b/ysos.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import argparse
+import glob
 
 
 parser = argparse.ArgumentParser(description="Build script for YSOS")
@@ -49,6 +50,12 @@ parser.add_argument(
     choices=["build", "clean", "launch", "run", "clippy"],
     default="build",
     help="Task to execute",
+)
+
+parser.add_argument(
+    "--vvfat_disabled",
+    action="store_true",
+    help="QEMU doesn't support vvfat",
 )
 
 args = parser.parse_args()
@@ -103,6 +110,7 @@ def qemu(
     memory: str = "96M",
     debug: bool = False,
     intdbg: bool = False,
+    vvfat_disabled: bool = False,
 ):
     qemu_exe = shutil.which("qemu-system-x86_64")
 
@@ -112,6 +120,29 @@ def qemu(
 
     if qemu_exe is None:
         raise Exception("qemu-system-x86_64 not found in PATH")
+
+    if vvfat_disabled:
+        esp = 'esp.img'
+
+        execute_command([
+            shutil.which("dd"),
+            "if=/dev/zero", f"of={esp}", "bs=1M", "count=64"
+        ])
+
+        execute_command([
+            shutil.which("mformat"),
+            "-i", esp,
+            "-t", "64", "-h", "32", "-s", "64", "::"
+        ])
+
+        execute_command([
+            shutil.which("mcopy"),
+            "-i", esp,
+            "-s", *glob.glob(os.path.join('esp', "*")),
+            "::/"
+        ])
+    else:
+        esp = 'fat:esp'
 
     qemu_args = [
         qemu_exe,
@@ -123,7 +154,7 @@ def qemu(
         "-m",
         memory,
         "-drive",
-        "format=raw,file=fat:esp",
+        f"format=raw,file={esp}",
         "-snapshot",
     ]
 
@@ -250,10 +281,10 @@ def main():
     elif args.task == "clean":
         clean()
     elif args.task == "launch":
-        qemu(args.output, args.memory, args.debug, args.intdbg)
+        qemu(args.output, args.memory, args.debug, args.intdbg, args.vvfat_disabled)
     elif args.task == "run":
         build()
-        qemu(args.output, args.memory, args.debug, args.intdbg)
+        qemu(args.output, args.memory, args.debug, args.intdbg, args.vvfat_disabled)
     elif args.task == "clippy":
         clippy()
 

--- a/ysos.py
+++ b/ysos.py
@@ -73,6 +73,11 @@ def debug(step: str, content: str):
     if args.verbose or args.dry_run:
         print(f"\033[1;34m[?] {step}:\033[0m \033[1m{content}\033[0m")
 
+def get_exe( str):
+    res = shutil.which(name)
+    if res is None:
+        raise Exception(f"{name} not found in PATH")
+    return res
 
 def get_apps():
     app_path = os.path.join(os.getcwd(), "crates", "app")
@@ -125,18 +130,18 @@ def qemu(
         esp = 'esp.img'
 
         execute_command([
-            shutil.which("dd"),
+            get_exe("dd")
             "if=/dev/zero", f"of={esp}", "bs=1M", "count=64"
         ])
 
         execute_command([
-            shutil.which("mformat"),
+            get_exe("mformat"),
             "-i", esp,
             "-t", "64", "-h", "32", "-s", "64", "::"
         ])
 
         execute_command([
-            shutil.which("mcopy"),
+            get_exe("mcopy"),
             "-i", esp,
             "-s", *glob.glob(os.path.join('esp', "*")),
             "::/"
@@ -187,10 +192,7 @@ def copy_to_esp(src: str, dst: str):
 
 
 def build():
-    cargo_exe = shutil.which("cargo")
-
-    if cargo_exe is None:
-        raise Exception("cargo not found in PATH")
+    cargo_exe = get_exe("cargo")
 
     # build uefi boot loader
     bootloader = os.path.join(os.getcwd(), "crates", "boot")
@@ -244,10 +246,7 @@ def build():
 
 
 def clippy():
-    cargo_exe = shutil.which("cargo")
-
-    if cargo_exe is None:
-        raise Exception("cargo not found in PATH")
+    cargo_exe = get_exe("cargo")
 
     info("Running", "cargo fmt on root...")
     execute_command([cargo_exe, "+nightly", "fmt", "--all"])
@@ -267,12 +266,7 @@ def clean():
     if os.path.exists(args.boot):
         shutil.rmtree(args.boot)
 
-    cargo_exe = shutil.which("cargo")
-
-    if cargo_exe is None:
-        raise Exception("cargo not found in PATH")
-
-    execute_command([cargo_exe, "clean"])
+    execute_command([get_exe("cargo"), "clean"])
 
 
 def main():

--- a/ysos.py
+++ b/ysos.py
@@ -73,7 +73,7 @@ def debug(step: str, content: str):
     if args.verbose or args.dry_run:
         print(f"\033[1;34m[?] {step}:\033[0m \033[1m{content}\033[0m")
 
-def get_exe( str):
+def get_exe(name: str):
     res = shutil.which(name)
     if res is None:
         raise Exception(f"{name} not found in PATH")
@@ -130,7 +130,7 @@ def qemu(
         esp = 'esp.img'
 
         execute_command([
-            get_exe("dd")
+            get_exe("dd"),
             "if=/dev/zero", f"of={esp}", "bs=1M", "count=64"
         ])
 


### PR DESCRIPTION
对于不支持 vvfat 的 qemu 环境无法直接挂载目录 `esp`，使用 python 脚本自动构建镜像。

原始需求是老师要求使用 Kylin OS 作为开发环境，该环境的 qemu 不支持 vvfat 这一安全隐患的功能。